### PR TITLE
Upgrade `libxmljs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "chalk": "^1.0.0",
     "cheerio": "^0.19.0",
     "fs": "0.0.2",
-    "libxmljs": "^0.18.2",
+    "libxmljs": "^0.19.7",
     "mkdirp": "^0.5.1",
     "path": "^0.11.14",
     "simplecrawler": "^0.4.1",


### PR DESCRIPTION
To fix

```
error /av-doc/grunt-ci-doc/node_modules/libxmljs: Command failed.
Exit code: 1
Command: node-pre-gyp install --fallback-to-build --loglevel http
Arguments: 
Directory: /av-doc/grunt-ci-doc/node_modules/libxmljs
Output:
node-pre-gyp http GET https://github.com/libxmljs/libxmljs/releases/download/v0.18.8/node-v72-linux-x64.tar.gz
node-pre-gyp http 404 https://github.com/libxmljs/libxmljs/releases/download/v0.18.8/node-v72-linux-x64.tar.gz
node-pre-gyp ERR! Tried to download(404): https://github.com/libxmljs/libxmljs/releases/download/v0.18.8/node-v72-linux-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for libxmljs@0.18.8 and node@12.13.0 (node-v72 ABI, glibc) (falling back to source compile with node-gyp) 
node-pre-gyp http 404 status code downloading tarball https://github.com/libxmljs/libxmljs/releases/download/v0.18.8/node-v72-linux-x64.tar.gz
```